### PR TITLE
Make it possible to vendor this package

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -66,21 +66,25 @@ let discover c =
   C.Flags.write_sexp "c_flags.sexp" c_flags;
   C.Flags.write_sexp "c_library_flags.sexp" libs
 
-let cppo file c =
+let cppo file cppo_bin c =
   let ocaml_version = C.ocaml_config_var_exn c "version" in
   let system = C.ocaml_config_var_exn c "system" in
   let arch = C.ocaml_config_var_exn c "architecture" in
   let has_usb = get_usb c <> None in
-  let cmd = sprintf "cppo -D %s -D %s%s -V OCAML:%s %s"
+  let cmd = sprintf "%s -D %s -D %s%s -V OCAML:%s %s"
+                       cppo_bin
                        system arch (if has_usb then " -D HAS_USB" else "")
                        ocaml_version (Filename.quote file) in
   ignore(Sys.command cmd)
 
 let () =
   let cppo_file = ref "" in
+  let cppo_bin = ref "cppo" in
   let specs = [
       ("--cppo", Arg.Set_string cppo_file,
-       " run cppo with the right arguments")] in
+       " run cppo with the right arguments");
+      ("--cppo-bin", Arg.Set_string cppo_bin,
+       " patht to the cppo binary to run")] in
   Arg.parse specs (fun _ -> raise(Arg.Bad "no anonymous arg")) "discover";
   C.main ~name:"mindstorm"
-    (if !cppo_file <> "" then cppo !cppo_file else discover)
+    (if !cppo_file <> "" then cppo !cppo_file !cppo_bin else discover)

--- a/lwt/dune
+++ b/lwt/dune
@@ -4,7 +4,7 @@
  (modules   Mindstorm_lwt Mindstorm_lwt__NXT Mindstorm_lwt_connect)
  (libraries mindstorm bytes unix lwt lwt.unix) ;lwt.preemptive)
  (wrapped false)
- (preprocess (action (run %{exe:../config/discover.exe} --cppo %{input-file})))
+ (preprocess (action (run %{exe:../config/discover.exe} --cppo %{input-file} --cppo-bin %{bin:cppo})))
  (preprocessor_deps ../src/mindstorm__NXT.ml
                     ../src/mindstorm_connect.ml ../src/mindstorm_connect.mli
                     ../src/mindstorm_macros.ml ../src/mindstorm_common.ml
@@ -16,8 +16,8 @@
 
 (rule
  (targets mindstorm_lwt__NXT.mli)
- (deps    ../src/mindstorm__NXT.mli.pp (:p %{workspace_root}/config/pp.exe))
- (action  (chdir %{workspace_root} (run %{p}))))
+ (deps    ../src/mindstorm__NXT.mli.pp (:p %{project_root}/config/pp.exe))
+ (action  (chdir %{project_root} (run %{p}))))
 
 (rule
  (targets c_flags.sexp c_library_flags.sexp)

--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,7 @@
  (modules    Mindstorm Mindstorm__NXT Mindstorm__EV3 Mindstorm_connect)
  (libraries  bytes unix)
  (wrapped false)
- (preprocess (action (run %{exe:../config/discover.exe} --cppo %{input-file})))
+ (preprocess (action (run %{exe:../config/discover.exe} --cppo %{input-file} --cppo-bin %{bin:cppo})))
  (preprocessor_deps mindstorm_connect.ml mindstorm_macros.ml
                     mindstorm_common.ml
                     mindstorm_win.c mindstorm_unix.c)
@@ -20,8 +20,8 @@
 ;; Generate the interface, so it is easily readable.
 (rule
  (targets mindstorm__NXT.mli)
- (deps    mindstorm__NXT.mli.pp (:p %{workspace_root}/config/pp.exe))
- (action  (chdir %{workspace_root} (run %{p}))))
+ (deps    mindstorm__NXT.mli.pp (:p %{project_root}/config/pp.exe))
+ (action  (chdir %{project_root} (run %{p}))))
 
 (rule
  (targets c_flags.sexp c_library_flags.sexp)


### PR DESCRIPTION
This fixes two problems that were preventing this package from working when vendored inside another dune project:

- Replace workspace_root with project_root in dune file. When a package is vendored inside another project, workspace_root is the top-level directory for the entire project whereas project_root is the vendored source directory for this package.

- Pass the path to the cppo binary to discover.exe. If cppo is vendored and not globally installed, dune can locate it (e.g. %{bin:cppo} in a dune file) but running "cppo" won't work.